### PR TITLE
Update language name

### DIFF
--- a/module.json
+++ b/module.json
@@ -10,7 +10,7 @@
     "languages" : [
       {
          "lang" : "sv",
-         "name" : "Swedish",
+         "name" : "Svenska",
          "path" : "sv.json"
       }
     ],


### PR DESCRIPTION
All the other languages are written in their respective languages. Therefore I think it should read "Svenska" instead of Swedish.